### PR TITLE
S2LP driver: fix infinite loop on rco calibration error

### DIFF
--- a/Drivers/BSP/Components/S2LP/s2lp.c
+++ b/Drivers/BSP/Components/S2LP/s2lp.c
@@ -270,9 +270,9 @@ void S2LP_RefreshStatus(void)
 }
 /**
   * @brief  FunctionDescription
-  * @retval None
+  * @retval Error code: S2LP_OK on success, S2LP_ERROR on error during calibration of RCO.
   */
-void S2LP_RcoCalibration(void)
+int32_t S2LP_RcoCalibration(void)
 {
   uint8_t tmp[2],tmp2;
 
@@ -286,21 +286,23 @@ void S2LP_RcoCalibration(void)
 
   do
   {
-    S2LP_ReadRegister(MC_STATE1_ADDR, 1, tmp);
-  }
-  while((tmp[0]& RCO_CAL_OK_REGMASK)==0);   /* Wait until RC_CAL_OK becomes 1 */
-  
-  
+    S2LP_RefreshStatus();
+    if(g_xStatus.ERROR_LOCK) {
+      return S2LP_ERROR;
+    }
+  } while(g_xStatus.RCCAL_OK == 0);   /* Wait until RC_CAL_OK becomes 1 */
+
   S2LP_ReadRegister(RCO_CALIBR_OUT4_ADDR, 2, tmp);
   S2LP_ReadRegister(RCO_CALIBR_CONF2_ADDR, 1, &tmp2);
-  
-  tmp[1]= (tmp[1] & TEMP_SENSOR_EN_REGMASK) | (tmp2 & 0x7F);
-  
+
+  tmp[1] = (tmp[1] & TEMP_SENSOR_EN_REGMASK) | (tmp2 & 0x7F);
+
   S2LP_WriteRegister(RCO_CALIBR_CONF3_ADDR, 2, tmp);
-  
+
   S2LP_ReadRegister(XO_RCO_CONF0_ADDR, 1, &tmp2);
   tmp2 &= 0xFE;
   S2LP_WriteRegister(XO_RCO_CONF0_ADDR, 1, &tmp2);
+  return S2LP_OK;
 }
 
 /**

--- a/Drivers/BSP/Components/S2LP/s2lp.h
+++ b/Drivers/BSP/Components/S2LP/s2lp.h
@@ -229,7 +229,7 @@ ModeExtRef S2LP_GetExtRef(void);
 void S2LP_SetExternalSmpsMode(SFunctionalState xNewState);
 void S2LP_RefreshStatus(void);
 void S2LP_StrobeCommand(S2LP_CMD_ xCommandCode);
-void S2LP_RcoCalibration(void);
+int32_t S2LP_RcoCalibration(void);
 void S2LP_EnableRangeExtMode(void);
 void S2LP_TCXOInit(void);
 /** @defgroup SPI_Exported_Macros       SPI Exported Macros


### PR DESCRIPTION
Modified the signiature of the `S2LP_RcoCalibration` method to return
`int32_t` instead of `void`, at `s2lp.h` and `s2lp.c`.

Changed the do-while loop which waits for the `RCCAL_OK` bit to be set,
so the loop body now checks the value of the `ERROR_LOCK` bit,
and returns an error code if the bit is set.
Accordingly, modified the function to return `S2LP_OK` when it is done
and no error was detected.

In addition, to clean up the code, I changed the way of querying the
MC_STATE register:
Instead of using `S2LP_ReadRegister` to directly read the `MC_STATE1`
register, I used the `S2LP_RefreshStatus` to read the update into
the global state variable `g_xStatus`, and then used it to get the value
of `ERROR_LOCK` and `RCCAL_OK` bits.
I believe this change makes the code cleaner.

At last, I fixed formatting in the function:
 - removed newline before the `while` loop
 - removed extra newline after the `do-while` block
 - added space before `=` sign

Fixes: https://github.com/STMicroelectronics/x-cube-subg2/issues/1