### PR TITLE
S2LP Driver: fixed code errors which break compilation

### DIFF
--- a/Drivers/BSP/Components/S2LP/s2lp.c
+++ b/Drivers/BSP/Components/S2LP/s2lp.c
@@ -43,6 +43,11 @@
 
 /* Private define ------------------------------------------------------------*/
 /* Private variables -------------------------------------------------------------*/
+/**
+ * @brief  S2LP Status global variable.
+ *         This global variable of @ref S2LPStatus type is updated on every SPI transaction
+ *         to maintain memory of S2LP Status.
+ */
 volatile S2LPStatus g_xStatus;
 /*!
  * @brief IO function pointer structure
@@ -170,86 +175,6 @@ StatusBytes S2LP_ReadFIFO(uint8_t cNbBytes, uint8_t* pcBuffer)
   ((uint8_t*)&status)[0]=header[1];
   
   return status;
-}
-
-/**
- * @brief  Set External Reference.
- * @param  xExtMode new state for the external reference.
- *         This parameter can be: MODE_EXT_XO or MODE_EXT_XIN.
- * @retval None.
- */
-void S2LP_SetExtRef(ModeExtRef xExtMode)
-{
-  uint8_t tmp;
-  S2LP_ReadRegister(XO_RCO_CONF0_ADDR, 1, &tmp);
-  if(xExtMode == MODE_EXT_XO) {
-    tmp &= ~EXT_REF_REGMASK;
-  }
-  else {
-    tmp |= EXT_REF_REGMASK;
-  }
-  g_xStatus = S2LP_WriteRegister(XO_RCO_CONF0_ADDR, 1, &tmp);
-
-}
-
-
-/**
- * @brief  Return External Reference.
- * @param  None.
- * @retval ModeExtRef Settled external reference.
- *         This parameter can be: MODE_EXT_XO or MODE_EXT_XIN.
- */
-ModeExtRef S2LP_GetExtRef(void)
-{
-  uint8_t tmp;
-  g_xStatus = S2LP_ReadRegister(XO_RCO_CONF0_ADDR, 1, &tmp);
-  return (ModeExtRef)(tmp & EXT_REF_REGMASK);
-}
-
-
-/**
- * @brief  Return device part number.
- * @param  None.
- * @retval Device part number.
- */
-uint8_t S2LP_GetDevicePN(void)
-{
-  uint8_t tmp;
-  g_xStatus = S2LP_ReadRegister(DEVICE_INFO1_ADDR, 1, &tmp);
-  return tmp;
-}
-
-/**
- * @brief  Return S2LP version.
- * @param  None.
- * @retval S2LP version.
- */
-uint8_t S2LP_GetVersion(void)
-{
-  uint8_t tmp;
-  S2LP_ReadRegister(DEVICE_INFO0_ADDR, 1, &tmp);
-  return tmp;
-}
-
-
-/**
-* @brief  Disable or enable the internal SMPS.
-* @param  xNewState if this value is S_DISABLE the external SMPS is enabled and a vlotage must be provided from outside.
-*               In this case the internal SMPS will be disabled.
-* @retval None.
-*/
-void S2LP_SetExternalSmpsMode(SFunctionalState xNewState)
-{
-  uint8_t tmp;
-  
-  S2LP_ReadRegister(PM_CONF4_ADDR, 1, &tmp);
-  
-  if(xNewState == S_ENABLE) {
-    tmp |= EXT_SMPS_REGMASK;
-  } else {
-    tmp &= ~EXT_SMPS_REGMASK;
-  }
-  g_xStatus = S2LP_WriteRegister(PM_CONF4_ADDR, 1, &tmp);
 }
 
 /**

--- a/Drivers/BSP/Components/S2LP/s2lp.h
+++ b/Drivers/BSP/Components/S2LP/s2lp.h
@@ -44,6 +44,7 @@
 #include "s2lp_gpio.h"
 #include "s2lp_timer.h"
 #include "s2lp_fifo.h"
+#include "s2lp_general.h"
 #include "s2lp_packethandler.h"
 #include "s2lp_pktwmbus.h"
 #include "s2lp_pktstack.h"
@@ -152,12 +153,6 @@ typedef struct
   S2LPBus_Delay                Delay;
 } S2LP_IO_t;
 
-typedef enum {
-  MODE_EXT_XO  = 0,
-  MODE_EXT_XIN = 0x80,
-} ModeExtRef;
-
-
 typedef enum
 {
   RANGE_EXT_NONE = 0,
@@ -185,8 +180,20 @@ typedef enum
 
 
 /* Exported constants --------------------------------------------------------*/    
-                                
+
 #define S2LPGeneralLibraryVersion() "S2LP_Libraries_v.1.3.0"
+
+/**
+ * @defgroup Types_Exported_Variables   Types Exported Variables
+ * @{
+ */
+
+extern volatile S2LPStatus g_xStatus;
+
+/**
+ * @}
+ */
+
 /* Exported macros --------------------------------------------------------*/    
 
 
@@ -222,11 +229,6 @@ StatusBytes S2LP_WriteFIFO(uint8_t cNbBytes, uint8_t* pcBuffer);
 StatusBytes S2LP_ReadFIFO(uint8_t cNbBytes, uint8_t* pcBuffer);
 
 
-uint8_t S2LP_GetDevicePN(void);
-uint8_t S2LP_GetVersion(void);
-void S2LP_SetExtRef(ModeExtRef xExtMode);
-ModeExtRef S2LP_GetExtRef(void);
-void S2LP_SetExternalSmpsMode(SFunctionalState xNewState);
 void S2LP_RefreshStatus(void);
 void S2LP_StrobeCommand(S2LP_CMD_ xCommandCode);
 int32_t S2LP_RcoCalibration(void);

--- a/Drivers/BSP/Components/S2LP/s2lp_general.c
+++ b/Drivers/BSP/Components/S2LP/s2lp_general.c
@@ -64,7 +64,7 @@
  * @defgroup General_Private_Defines            General Private Defines
  * @{
  */
-
+#define s_assert_param(expr) ((void)0U)
 /**
  *@}
  */
@@ -114,19 +114,19 @@
  *         This parameter can be: MODE_EXT_XO or MODE_EXT_XIN.
  * @retval None.
  */
-void S2LPGeneralSetExtRef(ModeExtRef xExtMode)
+void S2LP_SetExtRef(ModeExtRef xExtMode)
 {
   uint8_t tmp;
   s_assert_param(IS_MODE_EXT(xExtMode));
 
-  S2LPSpiReadRegisters(XO_RCO_CONF0_ADDR, 1, &tmp);
+  S2LP_ReadRegister(XO_RCO_CONF0_ADDR, 1, &tmp);
   if(xExtMode == MODE_EXT_XO) {
     tmp &= ~EXT_REF_REGMASK;
   }
   else {
     tmp |= EXT_REF_REGMASK;
   }
-  g_xStatus = S2LPSpiWriteRegisters(XO_RCO_CONF0_ADDR, 1, &tmp);
+  g_xStatus = S2LP_WriteRegister(XO_RCO_CONF0_ADDR, 1, &tmp);
 
 }
 
@@ -137,10 +137,10 @@ void S2LPGeneralSetExtRef(ModeExtRef xExtMode)
  * @retval ModeExtRef Settled external reference.
  *         This parameter can be: MODE_EXT_XO or MODE_EXT_XIN.
  */
-ModeExtRef S2LPGeneralGetExtRef(void)
+ModeExtRef S2LP_GetExtRef(void)
 {
   uint8_t tmp;
-  g_xStatus = S2LPSpiReadRegisters(XO_RCO_CONF0_ADDR, 1, &tmp);
+  g_xStatus = S2LP_ReadRegister(XO_RCO_CONF0_ADDR, 1, &tmp);
   return (ModeExtRef)(tmp & EXT_REF_REGMASK);
 }
 
@@ -150,10 +150,10 @@ ModeExtRef S2LPGeneralGetExtRef(void)
  * @param  None.
  * @retval Device part number.
  */
-uint8_t S2LPGeneralGetDevicePN(void)
+uint8_t S2LP_GetDevicePN(void)
 {
   uint8_t tmp;
-  g_xStatus = S2LPSpiReadRegisters(DEVICE_INFO1_ADDR, 1, &tmp);
+  g_xStatus = S2LP_ReadRegister(DEVICE_INFO1_ADDR, 1, &tmp);
   return tmp;
 }
 
@@ -162,10 +162,10 @@ uint8_t S2LPGeneralGetDevicePN(void)
  * @param  None.
  * @retval S2LP version.
  */
-uint8_t S2LPGeneralGetVersion(void)
+uint8_t S2LP_GetVersion(void)
 {
   uint8_t tmp;
-  S2LPSpiReadRegisters(DEVICE_INFO0_ADDR, 1, &tmp);
+  S2LP_ReadRegister(DEVICE_INFO0_ADDR, 1, &tmp);
   return tmp;
 }
 
@@ -176,19 +176,19 @@ uint8_t S2LPGeneralGetVersion(void)
 *               In this case the internal SMPS will be disabled.
 * @retval None.
 */
-void S2LPRadioSetExternalSmpsMode(SFunctionalState xNewState)
+void S2LP_SetExternalSmpsMode(SFunctionalState xNewState)
 {
   uint8_t tmp;
   s_assert_param(IS_SFUNCTIONAL_STATE(xNewState));
   
-  S2LPSpiReadRegisters(PM_CONF4_ADDR, 1, &tmp);
+  S2LP_ReadRegister(PM_CONF4_ADDR, 1, &tmp);
   
   if(xNewState == S_ENABLE) {
     tmp |= EXT_SMPS_REGMASK;
   } else {
     tmp &= ~EXT_SMPS_REGMASK;
   }
-  g_xStatus = S2LPSpiWriteRegisters(PM_CONF4_ADDR, 1, &tmp);
+  g_xStatus = S2LP_WriteRegister(PM_CONF4_ADDR, 1, &tmp);
 }
 
 /**

--- a/Drivers/BSP/Components/S2LP/s2lp_general.h
+++ b/Drivers/BSP/Components/S2LP/s2lp_general.h
@@ -99,7 +99,6 @@ typedef enum {
  * @defgroup General_Exported_Macros            General Exported Macros
  * @{
  */
-#define S2LPGeneralLibraryVersion() "S2LP_Libraries_v.1.3.0"
 
 
 /**
@@ -111,13 +110,12 @@ typedef enum {
  * @defgroup General_Exported_Functions         General Exported Functions
  * @{
  */
-
-uint8_t S2LPGeneralGetDevicePN(void);
-uint8_t S2LPGeneralGetVersion(void);
-void S2LPGeneralSetExtRef(ModeExtRef xExtMode);
-ModeExtRef S2LPGeneralGetExtRef(void);
-void S2LPRadioSetExternalSmpsMode(SFunctionalState xNewState);
-void S2LPRefreshStatus(void);
+ 
+uint8_t S2LP_GetDevicePN(void);
+uint8_t S2LP_GetVersion(void);
+void S2LP_SetExtRef(ModeExtRef xExtMode);
+ModeExtRef S2LP_GetExtRef(void);
+void S2LP_SetExternalSmpsMode(SFunctionalState xNewState);
 
 /**
  * @}

--- a/Drivers/BSP/Components/S2LP/s2lp_types.c
+++ b/Drivers/BSP/Components/S2LP/s2lp_types.c
@@ -86,13 +86,7 @@
 /** @defgroup Types_Private_Variables             Types Private Variables
  * @{
  */
-
-/**
- * @brief  S2LP Status global variable.
- *         This global variable of @ref S2LPStatus type is updated on every SPI transaction
- *         to maintain memory of S2LP Status.
- */
-volatile S2LPStatus g_xStatus;
+ 
 
 /**
  * @}
@@ -137,43 +131,6 @@ void s_assert_failed(uint8_t* file, uint32_t line)
 #endif
 
 
-/**
- * @brief  Updates the gState (the global variable used to maintain memory of S2LP Status)
- *         reading the MC_STATE register of S2LP.
- * @param  None
- * @retval None
- */
-#if 0 //indar
-void S2LPRefreshStatus(void)
-{
-  uint8_t tempRegValue[2];
-  /* Read the status both from register and from SPI header and exit when they match.
-      This will protect against possible transition state changes */
-  do
-  {
-    /* Reads the MC_STATUS register to update the g_xStatus */
-    g_xStatus = S2LPSpiReadRegisters(MC_STATE0_ADDR, 2, tempRegValue);
-  }
-  while(!((((uint8_t*)&g_xStatus)[0])==tempRegValue[1] && 
-          (((uint8_t*)&g_xStatus)[1]&0x07)==tempRegValue[0])); 
-
-}
-
-#else
-
-void S2LPRefreshStatus(void)
-{
-  uint8_t tempRegValue;
- // do
-  {
-    /* Reads the MC_STATUS register to update the g_xStatus */
-    g_xStatus = S2LPSpiReadRegisters(MC_STATE1_ADDR, 1, &tempRegValue);
-  }
-//  while(!((((uint8_t*)&g_xStatus)[0])==tempRegValue[1] && 
-//          (((uint8_t*)&g_xStatus)[1]&0x07)==tempRegValue[0])); 
-
-}
-#endif
 /**
  * @}
  */

--- a/Drivers/BSP/Components/S2LP/s2lp_types.h
+++ b/Drivers/BSP/Components/S2LP/s2lp_types.h
@@ -32,9 +32,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * This module provide some types definitions which will be used in
- * all the modules of this library. Here is defined also the global
- * variable @ref g_xStatus which contains the status of S2-LP and
- * is updated every time an SPI transaction occurs.
+ * all the modules of this library.
  *
  *
  * <h2><center>&copy; COPYRIGHT 2019 STMicroelectronics</center></h2>
@@ -162,7 +160,6 @@ typedef struct {
  * @{
  */
 
-extern volatile S2LPStatus g_xStatus;
 
 /**
  * @}


### PR DESCRIPTION
Replaced all calls to `S2LPSpiReadRegisters` with `S2LP_ReadRegister`,
and all calls to `S2LPSpiWriteRegisters` with `S2LP_WriteRegister`.
This fixes the undefined reference to the replaced functions.

Removed duplicate enum definition `ModeExtRef`, which was
originally defined in `s2lp.h`, while leaving a single definition
in `s2lp_general.h`, to align with the intent of `s2lp_general` files.

Defined macro for `s_assert_param` as it was undefined.
Later this macro should be removed (see the additional context of #3).

Included `s2lp_general.h` in `s2lp.h`.
Then removed duplicate functions defined in `s2lp_general.h`:
- `S2LPGeneralGetDevicePN`, replaced with `S2LP_GetDevicePN`
- `S2LPGeneralGetVersion`, replaced with `S2LP_GetVersion`
- `S2LPGeneralSetExtRef`,  replaced with `S2LP_SetExtRef`
- `S2LPGeneralGetExtRef`, replaced with `S2LP_GetExtRef`
- `S2LPRadioSetExternalSmpsMode`, replaced with `S2LP_SetExternalSmpsMode`
- Removed `S2LPRefreshStatus`, since it already
exists (and widely used) as `S2LP_RefreshStatus`.
The replaced functions were moved from `s2lp.c` to `s2lp_general.c`.
Accordingly, moved the function definitions from `s2lp.h` to `s2lp_general.h`
**This way, compatibility with the latest release version is kept**.

Moved the `g_xStatus` declaration to s2lp.h, and removed
the duplicate defitintion of `g_xStatus` from `s2lp_types.c`.
It is more reasonable to define it in `s2lp.h` and `s2lp.c`, since
this is a variable and not a type. This aligns with the definition
of the definition of  `S2LP_RefreshStatus` in the `s2lp.c` file,
as well as `IO_funcs` variable in `s2lp.c`.

Removed the duplicate `S2LPGeneralLibraryVersion()` macro
from `s2lp_general.h`.

This patch was successfully compiled in STM32CubeIde 1.8.0, and
was tested on a custom board with simple P2P app.

Fixes: https://github.com/STMicroelectronics/x-cube-subg2/issues/3

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/x-cube-subg2/blob/master/CONTRIBUTING.md) file.
